### PR TITLE
Add a new Makefile.def file for 64-bit computers.

### DIFF
--- a/Makefile.def-samples/Makefile.def-linux-generic
+++ b/Makefile.def-samples/Makefile.def-linux-generic
@@ -1,0 +1,35 @@
+# -------------------------------------------------------------------------
+# choose your compiler (must be ANSI-compliant!) and linker command, plus
+# any additionally needed flags
+
+CC = gcc
+LD = gcc
+CFLAGS = -g -O3 -fomit-frame-pointer -Wall
+LDFLAGS =
+#                    ^^^^^
+#                    |||||
+# adapt this to your target cpu (386/486 or higher)
+# note that older gcc versions require -m[34]86 instead of -mcpu=i[34]86,
+# while older ones might require '-march' instead of '-mcpu'. 
+# @GNU: why does this have to change every two years ?!
+
+TARG_OBJEXTENSION = .o
+
+HOST_OBJEXTENSION = $(TARG_OBJEXTENSION)
+
+# -------------------------------------------------------------------------
+# directories where binaries, includes, and manpages should go during
+# installation
+
+BINDIR = /usr/local/bin
+INCDIR = /usr/local/include/asl
+MANDIR = /usr/local/man
+LIBDIR = /usr/local/lib/asl
+DOCDIR = /usr/local/doc/asl
+
+# -------------------------------------------------------------------------
+# character encoding to use (choose one of them)
+
+CHARSET = CHARSET_ISO8859_1
+# CHARSET = CHARSET_ASCII7
+# CHARSET = CHARSET_IBM437


### PR DESCRIPTION
Makefile.def-linux-generic is the same as Makefile.def-i386-unknown-linux2.x.x except the -mcpu option was removed.